### PR TITLE
Specify crypto.pbkdf2 'digest' parameter (required since Node v8)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ Password.prototype.hash = function (password, salt, iterations, length) {
   length = length || this.length
   return (salt ? Promise.resolve(salt) : this.salt().then(toBase64))
     .then(function (_salt) {
-      return crypto.pbkdf2(password, salt = _salt, iterations, length)
+      return crypto.pbkdf2(password, salt = _salt, iterations, length, 'sha1')
     })
     .then(function (hash) {
       return [


### PR DESCRIPTION
Since Node v8, the `digest` parameter of `crypto.pbkdf2()` [must be specified](https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback). I set it to 'sha1' to ensure backward compatibility with [previous versions of Node](https://nodejs.org/dist/latest-v4.x/docs/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback).